### PR TITLE
fix toggle active class on body close menu

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -83,6 +83,7 @@ close.addEventListener('click', () => {
   navbar.classList.remove('overlay');
   navbar.classList.add('d-none');
   navbar.classList.remove('w-100');
+  body.classList.toggle('active');
 });
 
 // links functionality


### PR DESCRIPTION
I just fixed the bug that on close mobile menu the scroll comes back